### PR TITLE
Corrected literal string highlighting.

### DIFF
--- a/grammars/viml.cson
+++ b/grammars/viml.cson
@@ -134,7 +134,7 @@
   'string_quoted_single':
     'patterns': [
       {
-        'match': '\'(\\\\|\\\'|[^\\n\'])*\''
+        'match': '\'(\'\'|[^\\n\'])*\''
         'name': 'string.quoted.single.viml'
       }
     ]


### PR DESCRIPTION
Literal strings (single-quote strings) were having some sequences
incorrectly treated as escape sequences.

The only valid escape sequence in a literal string is a double
single-quote sequence, which expands to a single, single-quote
character.

For example the literal string:

```
'To insert a newline character, use the ''\n'' escape sequence.'
```

Is equivalent to the regular string:

```
"To insert a newline character, use the '\\n' escape sequence."
```

This commit fixes this behaviour.
