### PR TITLE
Fix autoload variables

### DIFF
--- a/grammars/viml.cson
+++ b/grammars/viml.cson
@@ -166,7 +166,7 @@ repository:
 	numbers:
 		patterns: [{
 			name: "constant.numeric.hex.viml"
-			match: "(?:#|0[xX])[0-9A-Fa-f]+"
+			match: "0[xX][0-9A-Fa-f]+"
 		},{
 			name: "constant.numeric.float.exponential.viml"
 			match: "(?<!\\w)-?\\d+\\.\\d+[eE][-+]?\\d+"


### PR DESCRIPTION
I found that some autoload variables' highlight is broken.

like:

```vim
let some_plugin#default_value = 10
```

or

https://twitter.com/b4b4r07/status/832552749124382721

AFAIK, there is no syntax where hex numbers precedes `#`. So I'd like to say to remove `#..` hex highlight from language-viml.

