### PR TITLE
Add 'range' and 'closure' to function attributes

### DIFF
--- a/grammars/viml.cson
+++ b/grammars/viml.cson
@@ -210,7 +210,7 @@ repository:
 				2: name: "punctuation.definition.scope.key-value.viml"
 		},{
 			name: "storage.modifier.$1.function.viml"
-			match: "(?<=\\)|\\s)(abort|dict)(?=\\s|$)"
+			match: "(?<=\\)|\\s)(abort|dict|closure|range)(?=\\s|$)"
 		}]
 	
 	augGroup:


### PR DESCRIPTION
`:function` definition can have `range` and `closure` attributes in addition to `dict` and `abort`. I added support for them in this PR. Please see `:help func-range` and `:help func-closure` for more details.

e.g.
```vim
let x = 42
function Foo() range abort dict closure
    echo x
endfunction
```